### PR TITLE
Make API content range header variable

### DIFF
--- a/heroku_tools/heroku.py
+++ b/heroku_tools/heroku.py
@@ -10,6 +10,7 @@ application release.
 
 """
 from dateutil import parser
+from os import getenv
 
 import click
 import requests
@@ -20,6 +21,7 @@ from . import settings
 HEROKU_API_URL_STEM = 'https://api.heroku.com/apps/%s/'
 HEROKU_API_URL_RELEASES = HEROKU_API_URL_STEM + 'releases'
 HEROKU_API_URL_CONFIG_VARS = HEROKU_API_URL_STEM + 'config-vars'
+HEROKU_API_MAX_RANGE = int(getenv('HEROKU_API_MAX_RANGE', 10))
 
 
 class HerokuError(Exception):
@@ -121,7 +123,7 @@ class HerokuRelease(object):
         releases = call_api(
             HEROKU_API_URL_RELEASES,
             application,
-            range_header='version;max=10,order=desc'
+            range_header='version;max=%i,order=desc' % HEROKU_API_MAX_RANGE
         )
 
         for release in releases:


### PR DESCRIPTION
I've added this is an environment var and not as a command switch
as I think it's orthogonal to the intent of any individual command, and
on a practical note, it's used by a number of functions, and rather than
adding an option to all of them, it seemed easier to add a single env var.

The var is HEROKU_API_MAX_RANGE, and it defaults to 10

Fixes #11 