### PR TITLE
Remove automatic migration execution; support via configuration instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .herokutoolsconf
 .tox/*
 PKG-INFO
+/.coverage
+/build
+/dist

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,7 @@
+v0.3
+====
+
+* Remove support for auto-detecting and running migrations from the main code.
+
+    * Instead, users must manually specify the comamnds to run via the post_deploy node in the configuration YAML. See settings/sample.conf for an example.
+    * This change provides better support for pipelined deployments.

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ In most cases it looks more like this:
 2. Turn on the app maintenance page
 3. Push up the code
 4. Run collectstatic ^^
-5. Run data migrations
+5. Run post-deployment tasks - eg: database migrations
 6. Turn off maintenance page
 7. Write a release note
 8. Inform others of the deployment
@@ -53,7 +53,7 @@ This project encapsulates these steps.
     $ heroku-tools deploy dev
     $ heroku-tools deploy dev --branch feature/xxx
 
-Migrations are run automatically if the changeset includes files under "/migrations/".
+The command to apply Migrations is specified via the configuration file as a post_deploy action. This is a change compared to version of Heroku-tools < 0.3
 
 Deployments
 -----------

--- a/heroku_tools/config.py
+++ b/heroku_tools/config.py
@@ -71,19 +71,9 @@ class AppConfiguration(object):
         return self.application.get('upstream', None)
 
     @property
-    def release_note(self):
-        """If True then prompt the user for a release note."""
-        return self.application.get('release_note', False)
-
-    @property
     def add_tag(self):
         """Add release version as a git tag post-deployment."""
         return self.application.get('add_tag', False)
-
-    @property
-    def add_rich_tag(self):
-        """Add a git tag with a release note post-deployment."""
-        return self.application.get('add_rich_tag', False)
 
     @property
     def post_deploy_tasks(self):

--- a/heroku_tools/config.py
+++ b/heroku_tools/config.py
@@ -85,6 +85,11 @@ class AppConfiguration(object):
         """Add a git tag with a release note post-deployment."""
         return self.application.get('add_rich_tag', False)
 
+    @property
+    def post_deploy_tasks(self):
+        """A list of strings to be executed as shell commands after deployment"""
+        return self.application.get('post_deploy', [])
+
 
 def compare_settings(local_config_vars, remote_config_vars):
     """Compare local and remote settings and return the diff.

--- a/heroku_tools/settings/__init__.py
+++ b/heroku_tools/settings/__init__.py
@@ -39,7 +39,6 @@ DEFAULT_SETTINGS = {
     'app_conf_dir': CWD,
     'git_work_dir': CWD,
     'commands': {
-        'migrate': 'python manage.py migrate',
         'collectstatic': 'python manage.py collectstatic --noinput',
     },
     'heroku_api_token': os.getenv('HEROKU_API_TOKEN'),
@@ -95,7 +94,6 @@ _settings = get_settings(os.path.join(os.getcwd(), '.herokutoolsconf'))
 app_conf_dir = _settings['app_conf_dir']
 git_work_dir = _settings['git_work_dir']
 commands = _settings['commands']
-migrate_cmd = commands['migrate']
 collectstatic_cmd = commands['collectstatic']
 heroku_api_token = _settings['heroku_api_token']
 
@@ -106,7 +104,6 @@ def print_settings():
     click.echo(r"-------------------------------------")
     click.echo(r"app_conf_dir      = %s" % app_conf_dir)
     click.echo(r"git_work_dir      = %s" % git_work_dir)
-    click.echo(r"migrate_cmd       = %s" % migrate_cmd)
     click.echo(r"collectstatic_cmd = %s" % collectstatic_cmd)
     click.echo(r"heroku_api_token  = %s" % heroku_api_token)
     click.echo(r"-------------------------------------")

--- a/heroku_tools/settings/sample.conf
+++ b/heroku_tools/settings/sample.conf
@@ -31,6 +31,16 @@ application:
     # if True add a release note to the tag (experimental)
     add_rich_tag: True
 
+    # Specify tasks to be run after deployment but before maintenance mode ends
+    # These are basically shell commands, so must explicitly reference the
+    # Heroku app with --app or -a as if on the CLI.
+
+    post_deploy:
+        - heroku run python manage.py migrate -a live_app --noinput
+        # if you have a pipeline, with more than one app in a node
+        # you will likely want to run commands for each app in that node
+        - heroku run python manage.py migrate -a live_app_two_also_in_pipeline  --noinput
+
 # Heroku application environment settings managed by the conf command
 settings:
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ REQUIREMENTS = '\n'.join(open(os.path.join(os.path.dirname(__file__), 'requireme
 
 setup(
     name='heroku-tools',
-    version='0.2.5',
+    version='0.3',
     url='https://github.com/yunojuno/heroku-tools',
     license='MIT',
     author='Hugo Rodger-Brown',


### PR DESCRIPTION
This changeset removes all code which previously autodetected the need to run migrations and then call `manage.py migrate` on the target app.  This behaviour did not play well with pipelined deployments that features multiple apps in a node.

Instead, post-deployment tasks (migrations being the key example) must now be specified via configuration, as a list of shell commands to run via a `post_deploy` node in the config YAML file.

See `settings/sample.conf` for an example of this.

It has been tested locally, but no code test coverage has been added. It can be, if necessary, but the changes are relatively clear

Other changes this squashed commit

* version bump to 0.3 - this is a breaking change
* add a changelog file
* update gitignore to exclude build, dist and coverage dirs

This changeset addresses #10 (and, indirectly #3 and #4). All three can be closed when this is merged